### PR TITLE
Use 301 instead of 307 for redirects

### DIFF
--- a/src/resources/redirect/src/java/org/wyona/yanel/impl/resources/redirect/RedirectResource.java
+++ b/src/resources/redirect/src/java/org/wyona/yanel/impl/resources/redirect/RedirectResource.java
@@ -78,7 +78,8 @@ public class RedirectResource extends Resource implements ViewableV2, CreatableV
         if (defaultHref == null) throw new Exception("No default redirect has been set!");
 
         // Default
-        response.setStatus(307);
+        int redirectCode = HttpServletResponse.SC_MOVED_PERMANENTLY; // In the age of SEO it is important to allow link juice, so only 301 should be used for redirects. See https://moz.com/learn/seo/redirection
+        response.setStatus(redirectCode); 
         response.setHeader("Location", defaultHref);
 
         ResourceConfiguration rc = getConfiguration();
@@ -96,7 +97,7 @@ public class RedirectResource extends Resource implements ViewableV2, CreatableV
             for (int i = 0; i < languageRedirectConfigs.length; i++) {
                 try {
                     if (languageRedirectConfigs[i].getAttribute("code").equals(localizationLanguage)) {
-                        response.setStatus(307);
+                        response.setStatus(redirectCode);
                         response.setHeader("Location", languageRedirectConfigs[i].getAttribute("href"));
                     }
                 } catch (Exception e) {


### PR DESCRIPTION
This is a very important fix for redirects with respect to SEO. 
According to many internet guidelines a redirect must be a 301 in order to retain the link juice.
Link Juice: URL A redirects to B. If you built up A for years and have a very high Page Rank, B will inherit the same page rank if you do a 301 redirect. If you perform a 302 or 307 (current Yanel impl), the ranking of page B starts at zero (which we want to avoid in any case!).

I had this patch since 2012 in our yanel based software but during my upgrade I thought that this should go into the official Yanel too!

References:
https://moz.com/learn/seo/redirection 
https://support.google.com/webmasters/answer/93633?hl=en