### PR TITLE
Introduce XSL Template Caching

### DIFF
--- a/src/impl/java/org/wyona/yanel/impl/resources/BasicXMLResource.java
+++ b/src/impl/java/org/wyona/yanel/impl/resources/BasicXMLResource.java
@@ -26,7 +26,9 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Properties;
 
+import javax.xml.transform.Source;
 import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.sax.SAXResult;
 import javax.xml.transform.sax.SAXTransformerFactory;
@@ -35,19 +37,15 @@ import javax.xml.transform.stream.StreamSource;
 
 import org.apache.avalon.framework.configuration.Configuration;
 import org.apache.avalon.framework.configuration.ConfigurationUtil;
-
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
-
 import org.apache.xml.resolver.tools.CatalogResolver;
 import org.apache.xml.serializer.Serializer;
 import org.apache.xml.utils.ListingErrorHandler;
 import org.w3c.dom.Document;
 import org.wyona.commons.io.MimeTypeUtil;
-
 import org.wyona.security.core.api.Identity;
 import org.wyona.security.core.api.User;
-
 import org.wyona.yanel.core.Resource;
 import org.wyona.yanel.core.api.attributes.ViewableV2;
 import org.wyona.yanel.core.attributes.viewable.View;
@@ -325,96 +323,111 @@ public class BasicXMLResource extends Resource implements ViewableV2 {
         xmlReader.setEntityResolver(catalogResolver);
         xmlReader.setFeature("http://xml.org/sax/features/namespace-prefixes", true);
 
-            SourceResolver uriResolver = new SourceResolver(this);
-            ListingErrorHandler errorListener = new ListingErrorHandler(new PrintWriter(errorWriter));
+        SourceResolver uriResolver = new SourceResolver(this);
+        ListingErrorHandler errorListener = new ListingErrorHandler(new PrintWriter(errorWriter));
 
-            // create xslt transformer:
-            SAXTransformerFactory tf = (SAXTransformerFactory)TransformerFactory.newInstance();
-            tf.setURIResolver(uriResolver);
-            tf.setErrorListener(errorListener);
+        // create xslt transformer:
+        SAXTransformerFactory tf = (SAXTransformerFactory)TransformerFactory.newInstance();
+        tf.setURIResolver(uriResolver);
+        tf.setErrorListener(errorListener);
 
-            String[] xsltPaths = null;
-            if (viewDescriptor != null) {
-                xsltPaths = viewDescriptor.getXSLTPaths();
+        String[] xsltPaths = null;
+        if (viewDescriptor != null) {
+            xsltPaths = viewDescriptor.getXSLTPaths();
+        } else {
+            log.warn("View descriptor is null!");
+        }
+        if (xsltPaths == null || xsltPaths.length == 0) {
+            xsltPaths = getXSLTPath(getPath());
+        }
+        
+
+        Repository repo = getRealm().getRepository();
+        TransformerHandler[] xsltHandlers = new TransformerHandler[xsltPaths.length];
+        for (int i = 0; i < xsltPaths.length; i++) {
+            String xsltPath = xsltPaths[i];
+            int schemeEndIndex = xsltPath.indexOf(':');
+            if (xsltPaths[i].startsWith("file:")) {
+                // TODO: Handle "file:" in SourceResolver
+                log.info("Scheme: file (" + xsltPaths[i] + ")");
+                xsltHandlers[i] = tf.newTransformerHandler(new StreamSource(new java.io.FileInputStream(xsltPaths[i].substring(5)), xsltPaths[i]));
+            } else if (schemeEndIndex >= 0) {
+                String scheme = xsltPath.substring(0, schemeEndIndex);
+                log.info("Scheme: " + scheme + " (" + xsltPath + ")");
+                
+                Source source = uriResolver.resolve(xsltPath, xsltPath);
+
+                xsltHandlers[i] = getTransformerHandler(source, tf); // per default, this is very slow.
+                /*XXX BACKWARD-COMPATIBILITY from now on we
+                    throw new SourceException("No resolver could be loaded for scheme: " + scheme);
+                instead of simply only doing
+                    log.error("No such protocol implemented: " + xsltPaths[i].substring(0, xsltPaths[i].indexOf(":/")));
+                and then probably also throwing some other exception anyway... 
+                */
             } else {
-                log.warn("View descriptor is null!");
+                    if (log.isDebugEnabled()) {
+                        log.debug("Default Content repository will be used!");
+                    }
+                xsltHandlers[i] = tf.newTransformerHandler(new StreamSource(repo.getNode(xsltPaths[i]).getInputStream(), "yanelrepo:" + xsltPaths[i]));
             }
-            if (xsltPaths == null || xsltPaths.length == 0) {
-                xsltPaths = getXSLTPath(getPath());
+            xsltHandlers[i].getTransformer().setURIResolver(uriResolver);
+            xsltHandlers[i].getTransformer().setErrorListener(errorListener);
+            //log.debug("Requested view ID: " + viewDescriptor.getId());
+            passTransformerParameters(xsltHandlers[i].getTransformer());
+        }
+
+        identity = getEnvironment().getIdentity();
+        user = null;
+        String userID = identity.getUsername();
+        if (userID != null) {
+            user = getRealm().getIdentityManager().getUserManager().getUser(userID);
+            //log.debug("User ID: " + userID + ", " + user.getID());
+        }
+        // create i18n transformer:
+        I18nTransformer3 i18nTransformer = new I18nTransformer3(getI18NCatalogueNames(), getRequestedLanguage(), getUserLanguage(identity, user), getRealm().getDefaultLanguage(), uriResolver);
+        i18nTransformer.setEntityResolver(catalogResolver);
+
+        // create xinclude transformer:
+        XIncludeTransformer xIncludeTransformer = new XIncludeTransformer();
+        xIncludeTransformer.setResolver(uriResolver);
+
+        // create serializer:
+        Serializer serializer = createSerializer(viewDescriptor);
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+
+        // chain everything together (create a pipeline):
+        if (xsltHandlers.length > 0) {
+            xmlReader.setContentHandler(xsltHandlers[0]);
+            for (int i=0; i<xsltHandlers.length-1; i++) {
+                xsltHandlers[i].setResult(new SAXResult(xsltHandlers[i+1]));
             }
-            
-            Repository repo = getRealm().getRepository();
-            // TBD: Introduce javax.xml.transform.Templates in order to cache transformers (see for example http://www.javaworld.com/article/2073394/java-xml/transparently-cache-xsl-transformations-with-jaxp.html)
-            TransformerHandler[] xsltHandlers = new TransformerHandler[xsltPaths.length];
-            identity = getEnvironment().getIdentity();
-            user = null;
-            String userID = identity.getUsername();
-            if (userID != null) {
-                user = getRealm().getIdentityManager().getUserManager().getUser(userID);
-                //log.debug("User ID: " + userID + ", " + user.getID());
-            }
-            for (int i = 0; i < xsltPaths.length; i++) {
-                String xsltPath = xsltPaths[i];
-                int schemeEndIndex = xsltPath.indexOf(':');
-                if (xsltPaths[i].startsWith("file:")) {
-                    // TODO: Handle "file:" in SourceResolver
-                    log.info("Scheme: file (" + xsltPaths[i] + ")");
-                    xsltHandlers[i] = tf.newTransformerHandler(new StreamSource(new java.io.FileInputStream(xsltPaths[i].substring(5)), xsltPaths[i]));
-                } else if (schemeEndIndex >= 0) {
-                    String scheme = xsltPath.substring(0, schemeEndIndex);
-                    log.info("Scheme: " + scheme + " (" + xsltPath + ")");
-                    xsltHandlers[i] = tf.newTransformerHandler(uriResolver.resolve(xsltPath, xsltPath));
-                    /*XXX BACKWARD-COMPATIBILITY from now on we
-                        throw new SourceException("No resolver could be loaded for scheme: " + scheme);
-                    instead of simply only doing
-                        log.error("No such protocol implemented: " + xsltPaths[i].substring(0, xsltPaths[i].indexOf(":/")));
-                    and then probably also throwing some other exception anyway... 
-                    */
-                } else {
-                        if (log.isDebugEnabled()) {
-                            log.debug("Default Content repository will be used!");
-                        }
-                    xsltHandlers[i] = tf.newTransformerHandler(new StreamSource(repo.getNode(xsltPaths[i]).getInputStream(), "yanelrepo:" + xsltPaths[i]));
-                }
-                xsltHandlers[i].getTransformer().setURIResolver(uriResolver);
-                xsltHandlers[i].getTransformer().setErrorListener(errorListener);
-                //log.debug("Requested view ID: " + viewDescriptor.getId());
-                passTransformerParameters(xsltHandlers[i].getTransformer());
-            }
+            xsltHandlers[xsltHandlers.length-1].setResult(new SAXResult(xIncludeTransformer));
+        } else {
+            xmlReader.setContentHandler(new SAXResult(xIncludeTransformer).getHandler());
+        }
+        xIncludeTransformer.setResult(new SAXResult(i18nTransformer));
+        i18nTransformer.setResult(new SAXResult(serializer.asContentHandler()));
+        serializer.setOutputStream(baos);
 
-            // create i18n transformer:
-            I18nTransformer3 i18nTransformer = new I18nTransformer3(getI18NCatalogueNames(), getRequestedLanguage(), getUserLanguage(identity, user), getRealm().getDefaultLanguage(), uriResolver);
-            i18nTransformer.setEntityResolver(catalogResolver);
+        // execute pipeline:
+        xmlReader.parse(new InputSource(xmlInputStream)); // TODO: as of different sources the parse method is not thread-safe! should be called within a synchronized block.
 
-            // create xinclude transformer:
-            XIncludeTransformer xIncludeTransformer = new XIncludeTransformer();
-            xIncludeTransformer.setResolver(uriResolver);
-
-            // create serializer:
-            Serializer serializer = createSerializer(viewDescriptor);
-
-            ByteArrayOutputStream baos = new ByteArrayOutputStream();
-
-            // chain everything together (create a pipeline):
-            if (xsltHandlers.length > 0) {
-                xmlReader.setContentHandler(xsltHandlers[0]);
-                for (int i=0; i<xsltHandlers.length-1; i++) {
-                    xsltHandlers[i].setResult(new SAXResult(xsltHandlers[i+1]));
-                }
-                xsltHandlers[xsltHandlers.length-1].setResult(new SAXResult(xIncludeTransformer));
-            } else {
-                xmlReader.setContentHandler(new SAXResult(xIncludeTransformer).getHandler());
-            }
-            xIncludeTransformer.setResult(new SAXResult(i18nTransformer));
-            i18nTransformer.setResult(new SAXResult(serializer.asContentHandler()));
-            serializer.setOutputStream(baos);
-
-            // execute pipeline:
-            xmlReader.parse(new InputSource(xmlInputStream));
-
-            return new ByteArrayInputStream(baos.toByteArray());
+        return new ByteArrayInputStream(baos.toByteArray());
     }
 
+    /**
+     * Override this method for your needs, e.g. with caching
+     * @param source
+     * @param tf
+     * @return
+     * @throws TransformerConfigurationException
+     */
+    protected TransformerHandler getTransformerHandler(Source source, SAXTransformerFactory tf) throws TransformerConfigurationException {
+        return tf.newTransformerHandler(source);
+    }
+    
+    
     /**
      * Creates an html or xml serializer for the given view descriptor
      * @param viewDescriptor

--- a/src/impl/java/org/wyona/yanel/impl/resources/XslTemplatesCache.java
+++ b/src/impl/java/org/wyona/yanel/impl/resources/XslTemplatesCache.java
@@ -1,0 +1,93 @@
+package src.impl.java.org.wyona.yanel.impl.resources;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import javax.xml.transform.Templates;
+
+import org.apache.log4j.Logger;
+
+/**
+ * This cache uses the ReentrantReadWriteLock from the java.util.concurrent.locks package instead of using synchronized code sections. 
+ * Reason to use ReentrantReadWriteLock : we expect many concurrent Read Threads and only very few write threads. 
+ * So we want to allow multiple read threads in parallel in order to improve performance.
+ * 
+ * @author baszero
+ */
+public class XslTemplatesCache {
+    protected static Logger log = Logger.getLogger(XslTemplatesCache.class);
+
+    private static volatile Map<String, Templates> templatesCache = new HashMap<String, Templates>();
+    private static final ReentrantReadWriteLock rwl = new ReentrantReadWriteLock(Boolean.TRUE); // true = fair policy, order of lock acquisition is preserved
+    private static final Lock r = rwl.readLock();
+    private static final Lock w = rwl.writeLock();
+
+    public static Templates get(String key) {
+        r.lock(); // here it only waits if another thread is writing to the cache
+        try {
+            return templatesCache.get(key);
+
+        } finally {
+            r.unlock();
+        }
+    }
+    
+    public static Templates put(String key, Templates value) {
+        w.lock(); // this thread waits until all preceding read threads have finished
+        try {
+            return templatesCache.put(key, value);
+
+        } finally {
+            w.unlock();
+        }
+    }
+
+    public static void clear() {
+        w.lock();
+        try {
+            templatesCache.clear();
+        } finally {
+            w.unlock();
+        }
+    }
+    
+    public static void clearSingle(String key) {
+        if (key != null) {
+            w.lock();
+            try {
+                templatesCache.remove(key);
+            } finally {
+                w.unlock();
+            }
+        }
+    }
+    
+    /**
+     * @return number of entries
+     */
+    public static int size() {
+        int result = -1;
+        r.lock();
+        try {
+            result = templatesCache.size();
+        } finally {
+            r.unlock();
+        }
+        return result;
+    }
+    
+    public static Set<String> getKeys() {
+        Set<String> result = null;
+        r.lock();
+        try {
+            result = templatesCache.keySet();
+        } finally {
+            r.unlock();
+        }
+        return result;
+    }
+
+}


### PR DESCRIPTION
This pull request actually does not yet MAKE USE of the caching, but it adapts the BasicXMLResource so that it is prepared for it. This pull request is 100% backwards compatible. So if this pull request gets merged into master, there is no difference to before.

The Cache implementation could be done in the new class XslTemplatesCache, this is just an example. Of course also another cache can be used.

An example of how to introduce actual caching is explained in https://github.com/wyona/yanel/issues/67#issuecomment-40081762