### PR TITLE
Heartbeat Job Example for non-concurrent execution

### DIFF
--- a/src/webapp/src/java/org/wyona/yanel/servlet/HeartbeatJobNonConcurrent.java
+++ b/src/webapp/src/java/org/wyona/yanel/servlet/HeartbeatJobNonConcurrent.java
@@ -1,0 +1,30 @@
+package org.wyona.yanel.servlet;
+
+import org.quartz.DisallowConcurrentExecution;
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.apache.log4j.Logger;
+import org.wyona.yanel.core.map.Realm;
+
+/**
+ * Heartbeat job
+ */
+@DisallowConcurrentExecution
+public class HeartbeatJobNonConcurrent implements Job {
+
+    private static Logger log = Logger.getLogger(HeartbeatJobNonConcurrent.class);
+
+    /**
+     * @see org.quartz.Job#execute(JobExecutionContext)
+     */
+    public void execute(JobExecutionContext context) throws JobExecutionException {
+        Realm realm = (Realm) context.getJobDetail().getJobDataMap().get("realm");
+        String realmName = null;
+        if (realm != null) {
+            realmName = realm.getName();
+        }
+        String description = context.getJobDetail().getDescription();
+        log.info("Heartbeat: " + new java.util.Date() + " (Realm: " + realmName + ", Description: " + description + ")"); // TODO: Show statistics, e.g. uptime, etc.
+    }
+}

--- a/src/webapp/src/java/org/wyona/yanel/servlet/HeartbeatJobNonConcurrent.java
+++ b/src/webapp/src/java/org/wyona/yanel/servlet/HeartbeatJobNonConcurrent.java
@@ -8,7 +8,8 @@ import org.apache.log4j.Logger;
 import org.wyona.yanel.core.map.Realm;
 
 /**
- * Heartbeat job
+ * Heartbeat job example that will not be executed again if one is already running. 
+ * Use this example for jobs that can take a lot more time than the scheduled time (e.g. job might run for 4h, but we let it run every 30min if it is not already running)
  */
 @DisallowConcurrentExecution
 public class HeartbeatJobNonConcurrent implements Job {


### PR DESCRIPTION
I think an example of how to implement a scheduled job that should not get executed in parallel was missing. So I added it. Simple but good to have.