### PR TITLE
Add sent date to mails before being sent out.

### DIFF
--- a/src/core/java/org/wyona/yanel/core/util/MailUtil.java
+++ b/src/core/java/org/wyona/yanel/core/util/MailUtil.java
@@ -285,6 +285,7 @@ private static PGPPublicKey getEncryptionKey(PGPPublicKeyRing keyRing) {
         } else {
             msg.setText(content, charset, mimeSubType);
         }
+        msg.setSentDate(new java.util.Date());
 
         // INFO: Send the message
         Transport.send(msg);


### PR DESCRIPTION
@michaelwechner Emails had been sent without the attribute 'sent date' properly set, thus resulting in missing date or other errors depending on receiving email client e.g. MS Outlook.